### PR TITLE
Kubernetes controllers

### DIFF
--- a/kubernetes-controllers/frontend-deployment.yaml
+++ b/kubernetes-controllers/frontend-deployment.yaml
@@ -1,0 +1,44 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: frontend
+  labels:
+    app: frontend
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: frontend
+  template:
+    metadata:
+      labels:
+        app: frontend
+    spec:
+      containers:
+      - name: server
+        image: knightlyflo/kuber-frontend:0.0.2
+        readinessProbe:
+          initialDelaySeconds: 10
+          httpGet:
+            path: "/_healthz"
+            port: 8080
+            httpHeaders:
+            - name: "Cookie"
+              value: "shop_session-id=x-readiness-probe"
+        env:
+        - name: PORT
+          value: "8080"
+        - name: PRODUCT_CATALOG_SERVICE_ADDR
+          value: "productcatalogservice:3550"
+        - name: CURRENCY_SERVICE_ADDR
+          value: "currencyservice:7000"
+        - name: CART_SERVICE_ADDR
+          value: "cartservice:7070"
+        - name: RECOMMENDATION_SERVICE_ADDR
+          value: "recommendationservice:8080"
+        - name: SHIPPING_SERVICE_ADDR
+          value: "shippingservice:50051"
+        - name: CHECKOUT_SERVICE_ADDR
+          value: "checkoutservice:5050"
+        - name: AD_SERVICE_ADDR
+          value: "adservice:9555"

--- a/kubernetes-controllers/frontend-replicaset.yaml
+++ b/kubernetes-controllers/frontend-replicaset.yaml
@@ -1,0 +1,36 @@
+apiVersion: apps/v1
+kind: ReplicaSet
+metadata:
+  name: frontend
+  labels:
+    app: frontend
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: frontend
+  template:
+    metadata:
+      labels:
+        app: frontend
+    spec:
+      containers:
+      - name: server
+        image: knightlyflo/kuber-frontend:0.0.2
+        env:
+        - name: PORT
+          value: "8080"
+        - name: PRODUCT_CATALOG_SERVICE_ADDR
+          value: "productcatalogservice:3550"
+        - name: CURRENCY_SERVICE_ADDR
+          value: "currencyservice:7000"
+        - name: CART_SERVICE_ADDR
+          value: "cartservice:7070"
+        - name: RECOMMENDATION_SERVICE_ADDR
+          value: "recommendationservice:8080"
+        - name: SHIPPING_SERVICE_ADDR
+          value: "shippingservice:50051"
+        - name: CHECKOUT_SERVICE_ADDR
+          value: "checkoutservice:5050"
+        - name: AD_SERVICE_ADDR
+          value: "adservice:9555"

--- a/kubernetes-controllers/node-exporter-daemonset.yaml
+++ b/kubernetes-controllers/node-exporter-daemonset.yaml
@@ -1,0 +1,62 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  labels:
+    app.kubernetes.io/component: exporter
+    app.kubernetes.io/name: node-exporter
+  name: node-exporter
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: exporter
+      app.kubernetes.io/name: node-exporter
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/component: exporter
+        app.kubernetes.io/name: node-exporter
+    spec:
+      tolerations:
+      # these tolerations are to have the daemonset runnable on control plane nodes
+      - key: node-role.kubernetes.io/control-plane
+        operator: Exists
+        effect: NoSchedule
+      - key: node-role.kubernetes.io/master
+        operator: Exists
+        effect: NoSchedule
+      containers:
+      - args:
+        - --path.sysfs=/host/sys
+        - --path.rootfs=/host/root
+        - --no-collector.wifi
+        - --no-collector.hwmon
+        - --collector.filesystem.ignored-mount-points=^/(dev|proc|sys|var/lib/docker/.+|var/lib/kubelet/pods/.+)($|/)
+        - --collector.netclass.ignored-devices=^(veth.*)$
+        name: node-exporter
+        image: prom/node-exporter
+        ports:
+          - containerPort: 9100
+            protocol: TCP
+        resources:
+          limits:
+            cpu: 250m
+            memory: 180Mi
+          requests:
+            cpu: 102m
+            memory: 180Mi
+        volumeMounts:
+        - mountPath: /host/sys
+          mountPropagation: HostToContainer
+          name: sys
+          readOnly: true
+        - mountPath: /host/root
+          mountPropagation: HostToContainer
+          name: root
+          readOnly: true
+      volumes:
+      - hostPath:
+          path: /sys
+        name: sys
+      - hostPath:
+          path: /
+        name: root

--- a/kubernetes-controllers/paymentservice-deployment-bg.yaml
+++ b/kubernetes-controllers/paymentservice-deployment-bg.yaml
@@ -1,0 +1,28 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: paymentservice
+  labels:
+    app: paymentservice
+spec:
+  replicas: 3
+  strategy:
+    rollingUpdate:
+      maxSurge: 3
+      maxUnavailable: 0
+  selector:
+    matchLabels:
+      app: paymentservice
+  template:
+    metadata:
+      labels:
+        app: paymentservice
+    spec:
+      containers:
+      - name: server
+        image: knightlyflo/kuber-paymentservice:0.0.2
+        env:
+        - name: PORT
+          value: "50051"
+        - name: DISABLE_PROFILER
+          value: "1"

--- a/kubernetes-controllers/paymentservice-deployment-reverse.yaml
+++ b/kubernetes-controllers/paymentservice-deployment-reverse.yaml
@@ -1,0 +1,28 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: paymentservice
+  labels:
+    app: paymentservice
+spec:
+  replicas: 3
+  strategy:
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: paymentservice
+  template:
+    metadata:
+      labels:
+        app: paymentservice
+    spec:
+      containers:
+      - name: server
+        image: knightlyflo/kuber-paymentservice:0.0.2
+        env:
+        - name: PORT
+          value: "50051"
+        - name: DISABLE_PROFILER
+          value: "1"

--- a/kubernetes-controllers/paymentservice-deployment.yaml
+++ b/kubernetes-controllers/paymentservice-deployment.yaml
@@ -1,0 +1,24 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: paymentservice
+  labels:
+    app: paymentservice
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: paymentservice
+  template:
+    metadata:
+      labels:
+        app: paymentservice
+    spec:
+      containers:
+      - name: server
+        image: knightlyflo/kuber-paymentservice:0.0.2
+        env:
+        - name: PORT
+          value: "50051"
+        - name: DISABLE_PROFILER
+          value: "1"

--- a/kubernetes-controllers/paymentservice-replicaset.yaml
+++ b/kubernetes-controllers/paymentservice-replicaset.yaml
@@ -1,0 +1,24 @@
+apiVersion: apps/v1
+kind: ReplicaSet
+metadata:
+  name: paymentservice
+  labels:
+    app: paymentservice
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: paymentservice
+  template:
+    metadata:
+      labels:
+        app: paymentservice
+    spec:
+      containers:
+      - name: server
+        image: knightlyflo/kuber-paymentservice:0.0.1
+        env:
+        - name: PORT
+          value: "50051"
+        - name: DISABLE_PROFILER
+          value: "1"


### PR DESCRIPTION
# Выполнено ДЗ №2 "Механика запуска и взаимодействия контейнеров в Kubernetes"

 - [x] Основное ДЗ
 - [x] Задание со *

## В процессе сделано:
 - Установил kind, развернул кластер командой `kind create cluster --config kind-config.yaml`
 
**ReplicaSet**
 - Скопировал описание ReplicaSet из домашнего задания и применил манифест. Появилась ошибка.

Задание: "Определите, что необходимо добавить в манифест, исправьте его и
примените вновь."
 - В манифесте не хватало параметра selector, который необходим для ReplicaSet, чтобы понимать, какими label контроллер может управлять.
```
  selector:
    matchLabels:
      app: frontend
```
- После запуска 1-й реплики, увеличил количество реплик командой `kubectl scale replicaset frontend --replicas=3`
- Проверил реплики на отказоустойчивость, удалив их. Контроллер ReplicaSet восстановил количество подов обратно до 3-х.

**Обновление ReplicaSet**
- Перетегировал образ knightlyflo/kuber-frontend:0.0.1 командой `docker tag knightlyflo/kuber-frontend:0.0.1 knightlyflo/kuber-frontend:0.0.2` и запушил его в Docker Hub.
- Обновил версию в манифесте на 0.0.2 и применил манифест. Поды не пересоздались при обновлении манифеста.
- Командой `kubectl get replicaset frontend -o=jsonpath='{.spec.template.spec.containers[0].image}'` проверил в ReplicaSet образ - тег 0.0.2
- Командой `kubectl get pods -l app=frontend -o=jsonpath='{.items[0:3].spec.containers[0].image}'` проверил образ, из котоого запущены поды - тег 0.0.1
- После удаления и пересоздания подов, образ изменился на 0.0.2

Задание: "Руководствуясь материалами лекции опишите произошедшую ситуацию,
почему обновление ReplicaSet не повлекло обновление запущенных pod?"
- Обновление ReplicaSet через применение нового манифеста поверх старого не работает, поскольку контроллер ReplicaSet не поддерживает обновления по стратегиям "recreate" или "rolling update". При обновлении ReplicaSet, созданные им поды перейдут под контроль обновлённого контроллера, но не пересоздадутся.
ReplicaSet рекомендуется использовать только для тех подов, которым не требуется обновляться. Если же поды необходимо обновлять, для этого необходимо использовать контроллер Deployment (например, в качестве объекта управления контроллером ReplicaSet), который поддерживает обновления подов.

**Deployment**
- Собрал образ knightlyflo/kuber-paymentservice из репозитория микросервиса paymentService с двумя тегами 0.0.1 и 0.0.2, запушил их в Docker Hub.
- Написал манифест paymentservice-replicaset.yaml на 3 реплики с образом 0.0.1
- Написал манифест paymentservice-deployment.yaml на основе предыдущего манифеста ReplicaSet, применил его.
- В результате в кластере появился deployment, replicaset и три пода.
- Изменил в манифесте тег образа на 0.0.2 и обновил Deployment. В результате старые поды заменились новыми подами с версией 0.0.2. Появился новый ReplicaSet для подов 0.0.2.
- Выполнил откат обновления на предыдущую версию 0.0.1 командой `kubectl rollout undo deployment paymentservice --to-revision=1`

**Задание со ⭐**
- С помощью параметров maxSurge и maxUnavailable написал два манифеста со специальным сценарием развёртывания:
  - paymentservice-deployment-bg.yaml - maxSurge: 3 / maxUnavailable: 0
  - paymentservice-deployment-reverse.yaml - maxSurge: 0 / maxUnavailable: 1

**Probes**
- Написал манифест frontend-deployment.yaml на 3 реплики с образом 0.0.1 и добавил туда readinessProbe.
- Протестировал работу Deployment при ошибке 404 на readinessProbe - новые поды не создавались, пока probe показывал ошибку.


**DaemonSet | Задание со ⭐**
- С помощью найденного в интернете манифеста, создал манифест nodeexporter-daemonset.yaml для образа Node Exporter с контроллером DaemonSet.
- Выполнил команду `kubectl port-forward node-exporter-7zdmv 9100:9100`, в результате метрики были доступны на localhost по порту 9100.

**DaemonSet | Задание с ⭐️⭐**
- Для того, чтобы разворачивать поды через контроллер DaemonSet не только на worker node, но и на control-plane/master node, необходимо добавить tolerations в манифест:
```
      tolerations:
      - key: node-role.kubernetes.io/control-plane
        operator: Exists
        effect: NoSchedule
      - key: node-role.kubernetes.io/master
        operator: Exists
        effect: NoSchedule
```
- Добавил необходимые параметры в манифест nodeexporter-daemonset.yaml, в результате чего на control-plane в кластере также появился под node-exporter.

## Как запустить проект:
- Развернуть кластер kind командой `kind cluster create`
- Применить манифесты из папки kubernetes-controllers командой `kubectl apply`.

## Как проверить работоспособность:
 - Выполнить команды, указанные в описании проделанной работы.

## PR checklist:
 - [x] Выставлен label с темой домашнего задания
