### PR TITLE
Kubernetes volumes

### DIFF
--- a/kubernetes-volumes/minio-headless-service.yaml
+++ b/kubernetes-volumes/minio-headless-service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: minio
+  labels:
+    app: minio
+spec:
+  clusterIP: None
+  ports:
+    - port: 9000
+      name: minio
+  selector:
+    app: minio

--- a/kubernetes-volumes/minio-secret.yaml
+++ b/kubernetes-volumes/minio-secret.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: minio-secret
+type: Opaque
+data:
+  MINIO_ACCESS_KEY: "bWluaW8="
+  MINIO_SECRET_KEY: "bWluaW8xMjM="

--- a/kubernetes-volumes/minio-statefulset.yaml
+++ b/kubernetes-volumes/minio-statefulset.yaml
@@ -1,0 +1,52 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  # This name uniquely identifies the StatefulSet
+  name: minio
+spec:
+  serviceName: minio
+  replicas: 1
+  selector:
+    matchLabels:
+      app: minio # has to match .spec.template.metadata.labels
+  template:
+    metadata:
+      labels:
+        app: minio # has to match .spec.selector.matchLabels
+    spec:
+      containers:
+      - name: minio
+        envFrom:
+        - secretRef:
+            name: minio-secret
+        image: minio/minio:RELEASE.2019-07-10T00-34-56Z
+        args:
+        - server
+        - /data 
+        ports:
+        - containerPort: 9000
+        # These volume mounts are persistent. Each pod in the PetSet
+        # gets a volume mounted based on this field.
+        volumeMounts:
+        - name: data
+          mountPath: /data
+        # Liveness probe detects situations where MinIO server instance
+        # is not working properly and needs restart. Kubernetes automatically
+        # restarts the pods if liveness checks fail.
+        livenessProbe:
+          httpGet:
+            path: /minio/health/live
+            port: 9000
+          initialDelaySeconds: 120
+          periodSeconds: 20
+  # These are converted to volume claims by the controller
+  # and mounted at the paths mentioned above. 
+  volumeClaimTemplates:
+  - metadata:
+      name: data
+    spec:
+      accessModes:
+        - ReadWriteOnce
+      resources:
+        requests:
+          storage: 10Gi


### PR DESCRIPTION
# Выполнено ДЗ №4 "Хранение данных в Kubernetes: Volumes, Storages, Statefull-приложения"

 - [x] Основное ДЗ
 - [x] Задание со *

## В процессе сделано:
 - Запустил кластер kind
 - Применил манифесты minio-statefulset.yaml, minio-headless-service.yaml
 - В результате появился statefulset minio, под minio-0, служба minio, PV data-minio-0 и PVC 
 - Командой `kubectl port-forward services/minio 9000:9000` можно вывести minio наружу

Задание со ⭐
- Создал манифест minio-secret.yaml
- Поместил туда env переменные из minio-statefulset.yaml
- Изменил манифест statefulset, чтобы тот мог читать env из secret:
```
        envFrom:
        - secretRef:
            name: minio-secret
```

## Как запустить проект:
 - Применить манифесты, пробросить службу minio наружу

## Как проверить работоспособность:
 - Например, выполнить `mc config host add minio-kuber http://localhost:9000 minio minio123` и попробовать добавить bucket 

## PR checklist:
 - [x] Выставлен label с темой домашнего задания
