### PR TITLE
Kubernetes monitoring

### DIFF
--- a/kubernetes-monitoring/deploy-nginx/nginx-ConfigMap.yaml
+++ b/kubernetes-monitoring/deploy-nginx/nginx-ConfigMap.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: nginx-configmap
+data:
+  default.conf: |
+    server {
+      listen 80;
+      server_name localhost;
+      
+      location /basic_status {
+        stub_status;
+        allow 127.0.0.1;
+        deny all;
+        }
+      }

--- a/kubernetes-monitoring/deploy-nginx/nginx-Deployment.yaml
+++ b/kubernetes-monitoring/deploy-nginx/nginx-Deployment.yaml
@@ -1,0 +1,38 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deploy
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: nginx-deploy
+  template:
+    metadata:
+      labels:
+        app: nginx-deploy
+    spec:
+      volumes:
+        - name: nginx-conf
+          configMap:
+            name: nginx-configmap
+            items:
+              - key: default.conf # link from ConfigMap
+                path: default.conf # where to mount inside mountPath
+      containers:
+      - name: nginx-server
+        image: nginx
+        resources: {}
+        ports:
+        - containerPort: 80
+        volumeMounts:
+          - mountPath: /etc/nginx/conf.d
+            name: nginx-conf
+            readOnly: true
+      - name: exporter
+        image: nginx/nginx-prometheus-exporter
+        args:
+          - '-nginx.scrape-uri=http://localhost/basic_status'
+        ports:
+          - containerPort: 9113
+        resources: {}

--- a/kubernetes-monitoring/deploy-nginx/nginx-Service.yaml
+++ b/kubernetes-monitoring/deploy-nginx/nginx-Service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: nginx-service
+  labels:
+    app: nginx-metrics
+spec:
+  selector:
+    app: nginx-deploy
+  type: ClusterIP
+  ports:
+  - name: nginxmon
+    port: 8080
+    targetPort: 9113
+    protocol: TCP

--- a/kubernetes-monitoring/deploy-nginx/nginx-ServiceMonitor.yaml
+++ b/kubernetes-monitoring/deploy-nginx/nginx-ServiceMonitor.yaml
@@ -1,0 +1,18 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: nginx-monitor
+  namespace: monitoring
+  labels:
+    release: prometheus-operator
+spec:
+  selector:
+    matchLabels:
+      app: nginx-metrics
+  endpoints:
+  - interval: 5s
+    path: /metrics
+    port: nginxmon
+  namespaceSelector:
+    matchNames:
+    - default


### PR DESCRIPTION
# Выполнено ДЗ №8 "Мониторинг компонентов кластера и приложений, работающих в нем"

 - [x] Основное ДЗ
 - [ ] Задание со *

## В процессе сделано:
 - Выбран уровень сложности "Bring'em on!" (привет фанатам вульфенштейна) - поставить prometheus-operator через kubectl apply из офф. репозитория
 - Создал кластер minikube с необходимыми параметрами для kube-prometheus
 - Установил kube-prometheus из официального репозитория [https://github.com/prometheus-operator/kube-prometheus](url)
 - Написал необходимые манифесты - ConfigMap, Deployment, Service, Servicemonitor в папке deploy-nginx

## Как запустить проект:
 - По инструкции из репозитория kube-prometheus:
 - 1. Запустить minikube с нужными опциями:
 ```
minikube delete && minikube start --kubernetes-version=v1.23.0 --memory=6g --bootstrapper=kubeadm --extra-config=kubelet.authentication-token-webhook=true --extra-config=kubelet.authorization-mode=Webhook --extra-config=scheduler.bind-address=0.0.0.0 --extra-config=controller-manager.bind-address=0.0.0.0
 ```
 - 2. Склонировать репо kube-prometheus нужной версии (для k8s v1.23.0 = release-0.10 или release-0.11):
```
git clone --single-branch -b release-0.11 https://github.com/prometheus-operator/kube-prometheus.git
```
 - 3. Установить kube-prometheus:
 ```
cd kube-prometheus/
kubectl apply --server-side -f manifests/setup
kubectl wait --for condition=Established --all CustomResourceDefinition --namespace=monitoring
kubectl apply -f manifests/
```
 - Установка kube-prometheus завершена, теперь необходимо применить манифесты из директории `kubernetes-monitoring/deploy-nginx`

## Как проверить работоспособность:
 - `kubectl --namespace monitoring port-forward services/prometheus-k8s 9090`
 - перейти по ссылке [http://localhost:9090/targets?search=#pool-serviceMonitor/monitoring/nginx-monitor/0](url)

## PR checklist:
 - [x] Выставлен label с темой домашнего задания
